### PR TITLE
Fix Issue with recursive folders.

### DIFF
--- a/Source/NSFileManager.m
+++ b/Source/NSFileManager.m
@@ -2584,6 +2584,10 @@ static inline void gsedRelease(GSEnumeratedDirectory X)
 	}
       else
 	{
+    // do not delete root folder from stack
+    if (GSIArrayCount(_stack) == 1) {
+      break;
+    }
 	  GSIArrayRemoveLastItem(_stack);
 	  if (_currentFilePath != 0)
 	    {

--- a/Source/NSFileManager.m
+++ b/Source/NSFileManager.m
@@ -2456,7 +2456,7 @@ static inline void gsedRelease(GSEnumeratedDirectory X)
  */
 - (void) skipDescendents
 {
-  if (GSIArrayCount(_stack) > 0)
+  if (GSIArrayCount(_stack) > 1)
     {
       GSIArrayRemoveLastItem(_stack);
       if (_currentFilePath != 0)
@@ -2584,10 +2584,6 @@ static inline void gsedRelease(GSEnumeratedDirectory X)
 	}
       else
 	{
-    // do not delete root folder from stack
-    if (GSIArrayCount(_stack) == 1) {
-      break;
-    }
 	  GSIArrayRemoveLastItem(_stack);
 	  if (_currentFilePath != 0)
 	    {


### PR DESCRIPTION
This PR addresses an issue in the NSDirectoryEnumerator where calling skipDescendents prematurely halts the directory enumeration process when the _stack data structure becomes empty. The root cause lies in the logic of skipDescendents, which previously removed the last item from _stack unconditionally when GSIArrayCount(_stack) > 0.